### PR TITLE
Create a sentry-native build workflow

### DIFF
--- a/.github/workflows/sentry-native-windows.yml
+++ b/.github/workflows/sentry-native-windows.yml
@@ -1,7 +1,6 @@
 name: Windows Build (sentry-native)
 
 on:
-  pull_request:
   workflow_dispatch:
     inputs:
       sentry-native-tag:


### PR DESCRIPTION
Create a workflow that can pull in and build the sentry-native source files and produce the supporting files that this library needs to consume. Eventually I hope that this workflow will be modified to create a nuget package out of the resulting binaries to allow for easier downstream consumption and dependency management, but this gets the ball rolling by being able to easily kick off a run that will successfully build the artifacts.

You can see a successful run here https://github.com/thebrowsercompany/swift-sentry/actions/runs/6488324832

We have a similar idea with `firebase-cpp-sdk` however I don't think it's worth forking the entire repo when we can simply clone it down into our workspace and build it without much issue. I'd like to avoid a fork since we're just building the upstream repo anyways.