### PR TITLE
Remove hard requirement on Info.plist

### DIFF
--- a/Sources/SwiftSentry/Options.swift
+++ b/Sources/SwiftSentry/Options.swift
@@ -13,9 +13,11 @@ public final class Options {
       return nil
     }
 
-    let bundle = info["CFBundleIdentifier"]!
-    let version = info["CFBundleShortVersionString"]!
-    let build = info["CFBundleVersion"]!
+    guard let bundle = info["CFBundleIdentifier"],
+          let version = info["CFBundleShortVersionString"],
+          let build = info["CFBundleVersion"] else {
+      return nil
+    }
 
     return "\(bundle)@\(version)+\(build)"
   }()


### PR DESCRIPTION
We shoudn't require everyone include an Info.plist with their project just to initialize Sentry correctly. If they happen to have one (in the case of macOS or iOS) we should auto-initialize a useful default.