### PR TITLE
Add breadcrumb apis and associated types

### DIFF
--- a/Examples/SentryExampleMacOS/main.swift
+++ b/Examples/SentryExampleMacOS/main.swift
@@ -1,17 +1,20 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
+import AppKit
 import Foundation
 import SwiftSentry
 
 @main
 enum MacOSExample {
+
     static func main() {
+        let app = NSApplication.shared
         startSentry()
         defer { Sentry.close() }
 
         print("Hello macOS")
 
-        RunLoop.current.run()
+        app.run()
     }
 
     static func startSentry() {

--- a/Examples/SentryExampleMacOS/main.swift
+++ b/Examples/SentryExampleMacOS/main.swift
@@ -23,6 +23,14 @@ enum MacOSExample {
 
             let user = User(userId: "1", email: "archie@arc.net")
             Sentry.setUser(user)
+
+            var crumb = Breadcrumb(withLevel: .warning, category: "info")
+            crumb.message = "We've started Sentry"
+            crumb.data = [
+                "processors": Int32(ProcessInfo.processInfo.activeProcessorCount)
+            ]
+
+            Sentry.addBreadcrumb(crumb)
         }
     }
 }

--- a/Sources/SwiftSentry/Breadcrumb.swift
+++ b/Sources/SwiftSentry/Breadcrumb.swift
@@ -29,7 +29,6 @@ extension Breadcrumb: SentryValueSerializable {
         sentry_value_set_by_key(crumb, "category", sentry_value_new_string(category.cString(using: .utf8)))
         sentry_value_set_by_key(crumb, "level", sentry_value_new_string(level.description.cString(using: .utf8)))
         sentry_value_set_by_key(crumb, "timestamp", sentry_value_new_double(timestamp.timeIntervalSince1970))
-        sentry_value_set_by_key(crumb, "message", sentry_value_new_string(message.cString(using: .utf8)))
 
         if let data {
             var object = sentry_value_new_object()

--- a/Sources/SwiftSentry/Breadcrumb.swift
+++ b/Sources/SwiftSentry/Breadcrumb.swift
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: BSD-3-Clause
+import sentry
+
+import Foundation
+
+/// A small piece of timestamped textual information that will accompany subsequent events.
+public struct Breadcrumb {
+    public var level: SentryLevel
+    public var category: String
+    public var timestamp: Date = .init()
+    public var type: String?
+    public var message: String?
+    public var data: [String: Any]?
+
+    public init(withLevel level: SentryLevel, category: String) {
+        self.level = level
+        self.category = category
+    }
+}
+
+extension Breadcrumb: SentryValueSerializable {
+    internal func serialized() -> sentry_value_t {
+        guard let message else {
+            return sentry_value_new_null()
+        }
+
+        let crumb = sentry_value_new_breadcrumb(type?.cString(using: .utf8), message.cString(using: .utf8))
+
+        sentry_value_set_by_key(crumb, "category", sentry_value_new_string(category.cString(using: .utf8)))
+        sentry_value_set_by_key(crumb, "level", sentry_value_new_string(level.description.cString(using: .utf8)))
+        sentry_value_set_by_key(crumb, "timestamp", sentry_value_new_double(timestamp.timeIntervalSince1970))
+        sentry_value_set_by_key(crumb, "message", sentry_value_new_string(message.cString(using: .utf8)))
+
+        if let data {
+            var object = sentry_value_new_object()
+            parse(value: &object, object: data)
+            sentry_value_set_by_key(crumb, "data", object)
+        }
+
+        return crumb
+    }
+
+    private func parse(value: inout sentry_value_t, object: [String: Any]) {
+        for (key, item) in object {
+            if let subDictionary = item as? [String: Any] {
+                var object = sentry_value_new_object()
+                parse(value: &object, object: subDictionary)
+                sentry_value_set_by_key(value, key.cString(using: .utf8), object)
+            } else if let subArray = item as? [Any] {
+                var list = sentry_value_new_list()
+                parse(value: &list, list: subArray, key: key)
+                sentry_value_set_by_key(value, key.cString(using: .utf8), list)
+            } else {
+                parse(value: &value, primitive: item, key: key)
+            }
+        }
+    }
+
+    private func parse(value: inout sentry_value_t, list: [Any], key: String) {
+        for item in list {
+            if let subArrayDictionary = item as? [String: Any] {
+                var object = sentry_value_new_object()
+                parse(value: &object, object: subArrayDictionary)
+                sentry_value_append(value, object)
+            } else if let subArrayArray = item as? [Any] {
+                var newList = sentry_value_new_list()
+                parse(value: &newList, list: subArrayArray, key: key)
+                sentry_value_append(value, newList)
+            } else {
+                parse(value: &value, primitive: item, key: key)
+            }
+        }
+    }
+
+    private func parse(value: inout sentry_value_t, primitive: Any, key: String) {
+        let cKey = key.cString(using: .utf8)
+        let isArray = sentry_value_get_type(value) == SENTRY_VALUE_TYPE_LIST
+
+        func convert(primitive: Any) -> sentry_value_t? {
+            switch primitive {
+            case is Int32:
+                return sentry_value_new_int32(primitive as! Int32)
+            case is Double:
+                return sentry_value_new_double(primitive as! Double)
+            case is Bool:
+                let bool = primitive as! Bool
+                return sentry_value_new_bool(bool ? 1 : 0)
+            case is String:
+                let cString = (primitive as! String).cString(using: .utf8)
+                return sentry_value_new_string(cString)
+            case is NSNull:
+                return sentry_value_new_null()
+            default:
+                return nil
+            }
+        }
+
+        guard let converted: sentry_value_t = convert(primitive: primitive) else { return }
+
+        if isArray {
+            sentry_value_append(value, converted)
+        } else {
+            sentry_value_set_by_key(value, cKey, converted)
+        }
+    }
+}

--- a/Sources/SwiftSentry/Sentry.swift
+++ b/Sources/SwiftSentry/Sentry.swift
@@ -64,6 +64,10 @@ public enum Sentry {
         sentry_set_user(user.serialized())
     }
 
+    public static func addBreadcrumb(_ breadcrumb: Breadcrumb) {
+        sentry_add_breadcrumb(breadcrumb.serialized())
+    }
+
     public static func close() {
         sentry_close()
     }

--- a/Sources/SwiftSentry/SentryLevel+Swift.swift
+++ b/Sources/SwiftSentry/SentryLevel+Swift.swift
@@ -34,6 +34,4 @@ extension SentryLevel: CustomStringConvertible {
             return "unknown"
         }
     }
-    
-
 }

--- a/Sources/SwiftSentry/SentryLevel+Swift.swift
+++ b/Sources/SwiftSentry/SentryLevel+Swift.swift
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: BSD-3-Clause
+import sentry
+
+public typealias SentryLevel = sentry_level_t
+
+/// A mapping of the ``sentry_level_t`` type to a Swiftier type
+///
+/// - note: The Cocoa SDK offers an additional level called `none`
+/// which will cause the SDK to not serialize any item marked with
+/// this level. The native SDK does not support this level, so it
+/// is notably missing here.
+extension SentryLevel {
+    public static var debug: Self { SENTRY_LEVEL_DEBUG }
+    public static var info: Self { SENTRY_LEVEL_INFO }
+    public static var warning: Self { SENTRY_LEVEL_WARNING }
+    public static var error: Self { SENTRY_LEVEL_ERROR }
+    public static var fatal: Self { SENTRY_LEVEL_FATAL }
+}
+
+extension SentryLevel: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case SENTRY_LEVEL_DEBUG:
+            return "debug"
+        case SENTRY_LEVEL_INFO:
+            return "info"
+        case SENTRY_LEVEL_WARNING:
+            return "warning"
+        case SENTRY_LEVEL_ERROR:
+            return "error"
+        case SENTRY_LEVEL_FATAL:
+            return "fatal"
+        default:
+            return "unknown"
+        }
+    }
+    
+
+}

--- a/Sources/SwiftSentry/SentryLevel+Swift.swift
+++ b/Sources/SwiftSentry/SentryLevel+Swift.swift
@@ -10,11 +10,11 @@ public typealias SentryLevel = sentry_level_t
 /// this level. The native SDK does not support this level, so it
 /// is notably missing here.
 extension SentryLevel {
-    public static var debug: Self { SENTRY_LEVEL_DEBUG }
-    public static var info: Self { SENTRY_LEVEL_INFO }
-    public static var warning: Self { SENTRY_LEVEL_WARNING }
-    public static var error: Self { SENTRY_LEVEL_ERROR }
-    public static var fatal: Self { SENTRY_LEVEL_FATAL }
+    public static let debug = SENTRY_LEVEL_DEBUG
+    public static let info = SENTRY_LEVEL_INFO
+    public static let warning = SENTRY_LEVEL_WARNING
+    public static let error = SENTRY_LEVEL_ERROR
+    public static let fatal = SENTRY_LEVEL_FATAL
 }
 
 extension SentryLevel: CustomStringConvertible {

--- a/Tests/SwiftSentryTests/BreadcrumbTests.swift
+++ b/Tests/SwiftSentryTests/BreadcrumbTests.swift
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: BSD-3-Clause
+@testable import SwiftSentry
+import XCTest
+
+final class BreadcrumbTests: XCTestCase {
+    func testBreadCrumbSerializesCorrectly() throws {
+        let crumb = Breadcrumb(withLevel: .debug, category: "http")
+        let serialized = crumb.serialized()
+        XCTAssertTrue(sentry_value_is_null(serialized) == 1)
+    }
+
+    func testNestedDataSerializedCorrectly() throws {
+        var crumb = Breadcrumb(withLevel: .debug, category: "http")
+        crumb.message = "hi"
+
+        crumb.data = [
+            "foo": true,
+            "fooList": ["l1", "l1", "l3"],
+            "fooListDict": ["one", [
+                "cool": false
+            ]],
+            "fooDict": [
+                "dk1": "dv1",
+                "dv2": [
+                    "dvn1": [Int32(1), Int32(2), Int32(3), Int32(4)]
+                ]
+            ],
+            "fooListNested": [Int32(8), [Int32(9), Int32(10)]],
+            "nullValue": NSNull()
+        ]
+
+        let json = try JSONDecoder().decode(BreadcrumbNestedSerialization.self, from:crumb.jsonData())
+
+        XCTAssertTrue(json.data.fooList.count == 3, "There should be three items set")
+        XCTAssertTrue(json.data.foo, "This should be true")
+    }
+
+    func testNestedListsSerializeCorrectly() throws {
+        var crumb = Breadcrumb(withLevel: .debug, category: "http")
+        crumb.message = "hi"
+
+        crumb.data = [
+            "nested": [["test"], ["test"], ["test"]]
+        ]
+
+        let json = try JSONDecoder().decode(BreadcrumbNestedLists.self, from: crumb.jsonData())
+
+        XCTAssertTrue(json.data.nested.count == 3, "There should be 3 sub-elements")
+        for item in json.data.nested {
+            XCTAssertEqual(item[0], "test", "The inner-most value should be equal to 'test'")
+        }
+    }
+
+    func testNestedDictionariesSerializeCorrectly() throws {
+        var crumb = Breadcrumb(withLevel: .debug, category: "http")
+        crumb.message = "hi"
+
+        crumb.data = [
+            "nested": [
+                "cool": [
+                    "values": [
+                        [Int32(1)], [Int32(1)], [Int32(1)]
+                    ]
+                ]
+            ]
+        ]
+
+        let json = try JSONDecoder().decode(BreadcrumbNestedObject.self, from: crumb.jsonData())
+        let inner = try XCTUnwrap(json.data.nested["cool"]?["values"])
+        for item in inner {
+            XCTAssertEqual(item[0], 1, "The inner-most value should be equal to 1")
+        }
+    }
+}
+
+extension Breadcrumb {
+    func jsonData() throws -> Data {
+        let serialized = serialized()
+        let jsonData = try XCTUnwrap(String(cString: sentry_value_to_json(serialized)).data(using: .utf8))
+
+        return jsonData
+    }
+}

--- a/Tests/SwiftSentryTests/Codables/BreadcrumbTestCodables.swift
+++ b/Tests/SwiftSentryTests/Codables/BreadcrumbTestCodables.swift
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+struct BreadcrumbNestedSerialization: Codable {
+    struct BreadcrumbDataTest: Codable {
+        let foo: Bool
+        let fooList: [String]
+    }
+
+    let category: String
+    let level: String
+    let data: BreadcrumbDataTest
+}
+
+struct BreadcrumbNestedLists: Codable {
+    struct BreadcrumbDataTest: Codable {
+        let nested: [[String]]
+    }
+
+    let category: String
+    let level: String
+    let data: BreadcrumbDataTest
+}
+
+struct BreadcrumbNestedObject: Codable {
+    struct BreadcrumbDataTest: Codable {
+        let nested: [String: [String: [[Int]]]]
+    }
+
+    let category: String
+    let level: String
+    let data: BreadcrumbDataTest
+}

--- a/Tests/SwiftSentryTests/Codables/BreadcrumbTestCodables.swift
+++ b/Tests/SwiftSentryTests/Codables/BreadcrumbTestCodables.swift
@@ -8,6 +8,7 @@ struct BreadcrumbNestedSerialization: Codable {
 
     let category: String
     let level: String
+    let message: String
     let data: BreadcrumbDataTest
 }
 
@@ -18,6 +19,7 @@ struct BreadcrumbNestedLists: Codable {
 
     let category: String
     let level: String
+    let message: String
     let data: BreadcrumbDataTest
 }
 
@@ -28,5 +30,6 @@ struct BreadcrumbNestedObject: Codable {
 
     let category: String
     let level: String
+    let message: String
     let data: BreadcrumbDataTest
 }


### PR DESCRIPTION
Create APIs for creating breadcrumbs and send them through to the Sentry SDK. In order to serialize the breadcrumbs I had to write a little bit of serialization code which is why I also provided tests that can run if you have the project setup. 

## Quirks
The Sentry SDK wants to serialize `int32_t` specifically for integers so I opted to require that type directly in order to correctly serialize things, which is a little annoying, but I think it's safer to bubble that responsibility up to the calling code rather than dealing with partial failures in the SDK itself.

## Testing
You can see a crash posted here with the right breadcrumb information

![CleanShot 2023-10-24 at 19 58 30@2x](https://github.com/thebrowsercompany/swift-sentry/assets/63919/af36b200-865c-4e1a-9cd1-467901d77cde)
