### PR TITLE
Provide default values for Breadcrumb

### DIFF
--- a/Sources/SwiftSentry/Breadcrumb.swift
+++ b/Sources/SwiftSentry/Breadcrumb.swift
@@ -12,7 +12,7 @@ public struct Breadcrumb {
     public var message: String?
     public var data: [String: Any]?
 
-    public init(withLevel level: SentryLevel, category: String) {
+    public init(withLevel level: SentryLevel = .info, category: String = "default") {
         self.level = level
         self.category = category
     }

--- a/Tests/SwiftSentryTests/BreadcrumbTests.swift
+++ b/Tests/SwiftSentryTests/BreadcrumbTests.swift
@@ -9,6 +9,12 @@ final class BreadcrumbTests: XCTestCase {
         XCTAssertTrue(sentry_value_is_null(serialized) == 1)
     }
 
+    func testBreadcrumbDefaultInitializer() throws {
+        let crumb = Breadcrumb()
+        XCTAssertEqual(crumb.level, SentryLevel.info, "Default level should be info.")
+        XCTAssertEqual(crumb.category, "default", "Default category should be 'default'.")
+    }
+
     func testNestedDataSerializedCorrectly() throws {
         var crumb = Breadcrumb(withLevel: .debug, category: "http")
         crumb.message = "hi"


### PR DESCRIPTION
 Breadcrumb, by default, in the Cocoa SDK uses .info and 'default' as the
    level and category respectively. We should mimic this API to allow for
    easier porting of shared code using swift-sentry.