### PR TITLE
Migrate to SentrySDK for main interface

### DIFF
--- a/Examples/SentryExampleMacOS/main.swift
+++ b/Examples/SentryExampleMacOS/main.swift
@@ -6,7 +6,6 @@ import SwiftSentry
 
 @main
 enum MacOSExample {
-
     static func main() {
         let app = NSApplication.shared
         startSentry()
@@ -19,7 +18,7 @@ enum MacOSExample {
 
     static func startSentry() {
         Task { @MainActor in
-            Sentry.start { options in
+            SentrySDK.start { options in
                 options.dsn = "your-dsn-goes-here"
                 options.debug = true
             }

--- a/Examples/SentryExampleWin/SentryExampleViewController.swift
+++ b/Examples/SentryExampleWin/SentryExampleViewController.swift
@@ -26,6 +26,8 @@ final class SentryExampleViewController: ViewController {
     badIndexButton.addTarget(self, action: SentryExampleViewController.badIndexAction,
                              for: .primaryActionTriggered)
 
+    print("App Crashed last session? \(SentrySDK.crashedLastRun)")
+
     layoutViews()
   }
 

--- a/Examples/SentryExampleWin/SentryExampleWin.swift
+++ b/Examples/SentryExampleWin/SentryExampleWin.swift
@@ -13,13 +13,13 @@ final class SentryExampleWin: ApplicationDelegate {
   }
 
   func applicationWillTerminate(_: Application) {
-    Sentry.close()
+    SentrySDK.close()
   }
 
   func startSentry() {
     print("Spinning up task to start Sentry")
     Task { @MainActor in
-      Sentry.start { options in
+      SentrySDK.start { options in
         options.dsn = SentryConfiguration.dsn
         options.environment = "Debug"
         options.debug = true

--- a/Sources/SwiftSentry/SentryId.swift
+++ b/Sources/SwiftSentry/SentryId.swift
@@ -6,7 +6,7 @@ import Foundation
 /// "12c2d058d58442709aa2eca08bf20986" or 36 character strings with dashes
 /// "12c2d058-d584-4270-9aa2-eca08bf20986".
 /// - note: It is recommended to omit dashes and use UUID v4 in cases.
-public struct SentryId {
+public struct SentryId: CustomStringConvertible {
   private let uuid: Foundation.UUID
 
   public init() {
@@ -36,8 +36,13 @@ public struct SentryId {
     self.uuid = uuid
   }
 
-  func sentryIdString() -> String {
+  public func sentryIdString() -> String {
     return uuid.uuidString.lowercased().replacingOccurrences(of: "-", with: "")
+  }
+
+  // MARK: - CustomStringConvertible
+  public var description: String {
+    return sentryIdString()
   }
 }
 

--- a/Sources/SwiftSentry/SentrySDK.swift
+++ b/Sources/SwiftSentry/SentrySDK.swift
@@ -5,15 +5,19 @@ import sentry
 
 import Foundation
 
-public enum Sentry {
-    @MainActor
+public enum SentrySDK {
+    /// Starts the SDK after passing in a closure to configure the options in the SDK.
+    /// - note: This should be called on the main thread/actor, but the annotation is
+    /// specifically not present to preserve cross-platform compatibility.
     public static func start(_ configureOptions: (inout Options) -> Void) {
         var options = Options()
         configureOptions(&options)
         start(options)
     }
 
-    @MainActor
+    /// Starts the SDK after passing in a closure to configure the options in the SDK.
+    /// - note: This should be called on the main thread/actor, but the annotation is
+    /// specifically not present to preserve cross-platform compatibility.
     public static func start(_ options: Options) {
         guard !options.dsn.isEmpty else {
             fatalError("Sentry DSN must not be empty!")

--- a/Sources/SwiftSentry/SentrySDK.swift
+++ b/Sources/SwiftSentry/SentrySDK.swift
@@ -6,6 +6,22 @@ import sentry
 import Foundation
 
 public enum SentrySDK {
+    /// Whether or not the application crashed during it's last run.
+    /// - note: This value is only accurate after the SDK have been initialized.
+    public static var crashedLastRun: Bool {
+        switch sentry_get_crashed_last_run() {
+            case 0:
+            return false
+            case 1:
+            return true
+            case -1:
+            // Since the Cocoa SDK expects a boolean value, and tri-bools aren't available
+            // we default to returning false if the SDK hasn't been initialized yet.
+            return false
+            default:
+            return false
+        }
+    }
     /// Starts the SDK after passing in a closure to configure the options in the SDK.
     /// - note: This should be called on the main thread/actor, but the annotation is
     /// specifically not present to preserve cross-platform compatibility.


### PR DESCRIPTION
 We also remove the @MainActor annotations to preserve cross platform
    compatibility. This is not specified in the macOS SDK so we should try
    to match those signatures as best we can. However, we can leave behind
    some documentation that it should be started on the main thread/actor.

While it would be more 'correct' to force things to be on the main actor, it changes the ergonomics too much in places where we're already starting the SDK. 