### PR TITLE
Fix the failed refactor of eventType

### DIFF
--- a/Sources/SwiftSentry/Event.swift
+++ b/Sources/SwiftSentry/Event.swift
@@ -42,8 +42,8 @@ extension Event: SentryValueSerializable {
       sentry_value_set_by_key(event, "message", sentry_value_new_string(message.cString(using: .utf8)))
     }
 
-    if let type {
-      sentry_value_set_by_key(event, "type", sentry_value_new_string(type.cString(using: .utf8)))
+    if let eventType {
+      sentry_value_set_by_key(event, "type", sentry_value_new_string(eventType.cString(using: .utf8)))
     }
 
     return event

--- a/Tests/SwiftSentryTests/EventTests.swift
+++ b/Tests/SwiftSentryTests/EventTests.swift
@@ -6,6 +6,7 @@ final class EventTests: XCTestCase {
   func testBasicEventGetsSerialized() throws {
     var event = Event(level: .info)
     event.message = "(❁´◡`❁)"
+    event.eventType = "message"
 
     let deserialized =  try JSONDecoder().decode(EventTestBasicEventSerialization.self, from: event.jsonData())
 


### PR DESCRIPTION
I didn't check if my refactor of `event` to `eventType` took everywhere, and I missed a spot. This fixes that and also ensures that we have it's mutability covered in a test.