### PR TITLE
Use classes for main SDK objects

### DIFF
--- a/Sources/SwiftSentry/Breadcrumb.swift
+++ b/Sources/SwiftSentry/Breadcrumb.swift
@@ -4,7 +4,7 @@ import sentry
 import Foundation
 
 /// A small piece of timestamped textual information that will accompany subsequent events.
-public struct Breadcrumb {
+public final class Breadcrumb {
     public var level: SentryLevel
     public var category: String
     public var timestamp: Date = .init()

--- a/Sources/SwiftSentry/Event.swift
+++ b/Sources/SwiftSentry/Event.swift
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 import Foundation
 
-public struct Event {
+public final class Event {
   public let eventId = SentryId()
   public var message: String?
   public var eventType: String?

--- a/Tests/SwiftSentryTests/BreadcrumbTests.swift
+++ b/Tests/SwiftSentryTests/BreadcrumbTests.swift
@@ -16,7 +16,7 @@ final class BreadcrumbTests: XCTestCase {
     }
 
     func testNestedDataSerializedCorrectly() throws {
-        var crumb = Breadcrumb(withLevel: .debug, category: "http")
+        let crumb = Breadcrumb(withLevel: .debug, category: "http")
         crumb.message = "hi"
 
         crumb.data = [
@@ -42,7 +42,7 @@ final class BreadcrumbTests: XCTestCase {
     }
 
     func testNestedListsSerializeCorrectly() throws {
-        var crumb = Breadcrumb(withLevel: .debug, category: "http")
+        let crumb = Breadcrumb(withLevel: .debug, category: "http")
         crumb.message = "hi"
 
         crumb.data = [
@@ -58,7 +58,7 @@ final class BreadcrumbTests: XCTestCase {
     }
 
     func testNestedDictionariesSerializeCorrectly() throws {
-        var crumb = Breadcrumb(withLevel: .debug, category: "http")
+        let crumb = Breadcrumb(withLevel: .debug, category: "http")
         crumb.message = "hi"
 
         crumb.data = [

--- a/Tests/SwiftSentryTests/EventTests.swift
+++ b/Tests/SwiftSentryTests/EventTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 final class EventTests: XCTestCase {
   func testBasicEventGetsSerialized() throws {
-    var event = Event(level: .info)
+    let event = Event(level: .info)
     event.message = "(❁´◡`❁)"
     event.eventType = "message"
 
@@ -23,7 +23,7 @@ final class EventTests: XCTestCase {
   }
 
   func testEventWithTagsGetsSerialized() throws {
-    var event = Event(level: .warning)
+    let event = Event(level: .warning)
     event.tags = [
       "one": "valueOne",
       "two": "valueTwo"


### PR DESCRIPTION
Anyone using the existing Cocoa SDK apis are going to expect reference
semantics and usage patterns with the objects coming out of this SDK.
While we can get by for the most part by using pure value types,
consumers of this SDK will run into issues if they are trying to use this as a drop in replacement.

## Example
The following code sample will not work without this change:
```swift
let breadcrumb = Breadcrumb()
breadcrumb.message = "Hi Mom"
```

but it should since this works in the Cocoa SDK. With these code changes, this sample will run just fine.