### PR TITLE
User should be a class

### DIFF
--- a/Sources/SwiftSentry/User.swift
+++ b/Sources/SwiftSentry/User.swift
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BSD-3-Clause
 /// The representation of a user which should be attached to subsequent events.
-public struct User {
-    var userId: String?
-    var email: String?
-    var username: String?
+public final class User {
+    public var userId: String?
+    public var email: String?
+    public var username: String?
 
     public init(
         userId: String? = nil,

--- a/Tests/SwiftSentryTests/UserTests.swift
+++ b/Tests/SwiftSentryTests/UserTests.swift
@@ -23,4 +23,14 @@ final class SwiftSentryTests: XCTestCase {
             XCTAssertEqual(value, group.1, "Expected value of '\(group.0)' to be '\(group.1)'; got '\(value)'")
         }
     }
+
+    func testCanMutateValuesAfterInitialization() throws {
+      let user = User()
+
+      XCTAssertNil(user.email)
+
+      user.email = "gritty@arc.net"
+
+      XCTAssertEqual(user.email, "gritty@arc.net")
+    }
 }


### PR DESCRIPTION
In order to match the reference API we are aligning against, the `User` object should really be a class that can have it's properties mutated after the fact.