### PR TITLE
Add Options Environment To Hashing Calculation

### DIFF
--- a/Sources/SwiftSentry/SentrySDK.swift
+++ b/Sources/SwiftSentry/SentrySDK.swift
@@ -49,9 +49,14 @@ public enum SentrySDK {
             fatalError("Unable to find caches directory for storing Sentry reports!")
         }
 
+        // Use the dsn + environment to create some variability in the hash
+        // to put the same app running in different environments in different
+        // places on disk to avoid any potential contention.
+        let applicationHash = "\(options.dsn)\(options.environment)".hash
+
         let sentryCachePath = cachePath
             .appendingPathComponent("io.sentry")
-            .appendingPathComponent(String(options.dsn.hash))
+            .appendingPathComponent(String(applicationHash))
             .path
 
         sentry_options_set_database_path(o, sentryCachePath.cString(using: .utf8))

--- a/Sources/SwiftSentry/SentrySDK.swift
+++ b/Sources/SwiftSentry/SentrySDK.swift
@@ -52,11 +52,12 @@ public enum SentrySDK {
         // Use the dsn + environment to create some variability in the hash
         // to put the same app running in different environments in different
         // places on disk to avoid any potential contention.
-        let applicationHash = "\(options.dsn)\(options.environment)".hash
+        var hasher = Hasher()
+        [options.dsn, options.environment].hash(into: &hasher)
 
         let sentryCachePath = cachePath
             .appendingPathComponent("io.sentry")
-            .appendingPathComponent(String(applicationHash))
+            .appendingPathComponent(String(hasher.finalize()))
             .path
 
         sentry_options_set_database_path(o, sentryCachePath.cString(using: .utf8))


### PR DESCRIPTION
When debugging an issue, Saleem and I noticed that the implementation for figuring out the cache path doesn't account for any kind of process isolation or running the same app multiple times, or in different environments. Looking through the C# code there is some mention of really wanting process isolation for these files eventually but not having a mechanism to perform such an action, https://github.com/getsentry/sentry-dotnet/blob/d3f2f7a5b4d4f549f4b4584d2c11dc8500907ff2/src/Sentry/GlobalSessionManager.cs#L40-L42.

While this does not process isolate these files it might be enough to ensure if we're running an app in Canary and RC (for example) that we don't get any issues with crash reporting