### PR TITLE
Use consistent SHA1 hashing for folder path

### DIFF
--- a/Sources/SwiftSentry/Utilities/Hashing.swift
+++ b/Sources/SwiftSentry/Utilities/Hashing.swift
@@ -1,0 +1,52 @@
+import Foundation
+#if canImport(WinSDK)
+import WinSDK
+#elseif canImport(CommonCrypto)
+import CommonCrypto
+#endif
+
+extension Data {
+  var SHA1: Data {
+    #if canImport(WinSDK)
+    func handleError(_ status: WinSDK.NTSTATUS) {
+      // Failfast to mimic CryptoKit/Crypto semantics
+      if status < 0 { fatalError("Failed to create SHA1 digest using BCrypt APIs (NTSTATUS: \(status))") }
+    }
+
+    let BCRYPT_SHA1_ALGORITHM = "SHA1"
+
+    var algorithm: WinSDK.BCRYPT_ALG_HANDLE?
+    BCRYPT_SHA1_ALGORITHM.withCString(encodedAs: UTF16.self) {
+      handleError(WinSDK.BCryptOpenAlgorithmProvider(&algorithm, $0, nil, 0))
+    }
+    defer { handleError(WinSDK.BCryptCloseAlgorithmProvider(algorithm, 0)) }
+
+    var hash: BCRYPT_HASH_HANDLE?
+    handleError(WinSDK.BCryptCreateHash(algorithm, &hash, nil, 0, nil, 0, 0))
+    defer { handleError(WinSDK.BCryptDestroyHash(hash)) }
+
+    withUnsafeBytes { (buffer: UnsafeRawBufferPointer) in
+        let input = UnsafeMutablePointer(mutating: buffer.baseAddress?.bindMemory(to: UInt8.self, capacity: buffer.count))
+        handleError(WinSDK.BCryptHashData(hash, input, ULONG(buffer.count), 0))
+    }
+
+    var result = Data(count: 20) // Size of SHA1 hash
+    result.withUnsafeMutableBytes { (buffer: UnsafeMutableRawBufferPointer) in
+        let output = buffer.baseAddress?.bindMemory(to: UInt8.self, capacity: buffer.count)
+        handleError(WinSDK.BCryptFinishHash(hash, output, ULONG(buffer.count), 0))
+    }
+
+    return result
+    #elseif canImport(CommonCrypto)
+    var digest = [UInt8](repeating: 0, count: Int(CC_SHA1_DIGEST_LENGTH))
+    withUnsafeBytes {
+        _ = CC_SHA1($0.baseAddress, CC_LONG(count), &digest)
+    }
+    return Data(digest)
+    #else
+    fatalError("No viable crypto implementation to back hashing function!")
+    #endif
+  }
+
+  var hexString: String { map { String(format: "%02x", $0) }.joined() }
+}

--- a/Tests/SwiftSentryTests/SentrySDKTests.swift
+++ b/Tests/SwiftSentryTests/SentrySDKTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+
+@testable import SwiftSentry
+
+final class SentrySDKTests: XCTestCase {
+  func testOptionsHashingIsConsistent() throws {
+    let options = Options()
+    options.dsn = "https://hello@world.com"
+    options.environment = "testing"
+
+    let path = SentrySDK.getCachePath(for: options)
+
+    for _ in 0..<10 {
+      let newPath = SentrySDK.getCachePath(for: options)
+
+      XCTAssertEqual(path, newPath)
+    }
+
+    options.environment = "debug"
+    let debugPath = SentrySDK.getCachePath(for: options)
+
+    XCTAssertNotEqual(path, debugPath)
+  }
+
+  func testTwoOptionsWithSameValuesProduceSamePath() throws {
+    let optionsOne = Options()
+    optionsOne.dsn = "https://hello@world.com"
+
+    let optionsTwo = Options()
+    optionsTwo.dsn = "https://hello@world.com"
+
+    XCTAssertEqual(SentrySDK.getCachePath(for: optionsOne), SentrySDK.getCachePath(for: optionsTwo))
+  }
+}


### PR DESCRIPTION
We have to use a consistent hashing mechanism and stable input to ensure that we are always creating the same output values across launches since this determines the folder on disk where crash information is stored. Using a Hasher across launches is bad behavior since they are seeded with different values across launches https://developer.apple.com/documentation/swift/hasher. 

We're using SHA1 since that's what the Cocoa SDK also uses to hash it's value. 