### PR TITLE
Fix scene configuration name to match module

### DIFF
--- a/Examples/SentryExampleWin/Info.plist
+++ b/Examples/SentryExampleWin/Info.plist
@@ -20,7 +20,7 @@
         <key>SceneConfigurationName</key>
         <string>Default Configuration</string>
         <key>SceneDelegateClassName</key>
-        <string>SentryExample.SceneDelegate</string>
+        <string>SentryExampleWin.SceneDelegate</string>
       </dict>
     </array>
     </dict>


### PR DESCRIPTION
This just fixes the scene configuration name so you can easily build and run from VS Code. This broke when I renamed the examples and we just needed to update the name.