### PR TITLE
Provide option to override handler path.

### DIFF
--- a/Sources/SwiftSentry/Options.swift
+++ b/Sources/SwiftSentry/Options.swift
@@ -6,6 +6,11 @@ public final class Options {
   public var attachStacktrace: Bool = false
   public var environment: String = "production"
   public var enableCrashHandler: Bool = true
+  /// Override the path to the preferred crash handler executable
+  /// - note: If this path doesn't resolve correctly, the crash backend
+  /// will fail to load. You can debug this by turning on the ``debug``
+  /// value and inspecting the logs.
+  public var crashHandlerPath: URL?
   public var beforeSend: ((AnyObject) -> AnyObject)?
   public var debug: Bool = false
   public var releaseName: String? = {

--- a/Sources/SwiftSentry/SentrySDK.swift
+++ b/Sources/SwiftSentry/SentrySDK.swift
@@ -54,7 +54,7 @@ public enum SentrySDK {
         }
 
         if let handlerPath = options.crashHandlerPath {
-          sentry_options_set_handler_path(o, handlerPath.path.cString(using: .utf8))
+          sentry_options_set_handler_path(o, handlerPath.withUnsafeFileSystemRepresentation { String(cString: $0!) }.cString(using: .utf8))
         }
 
         if let release = options.releaseName {

--- a/Sources/SwiftSentry/SentrySDK.swift
+++ b/Sources/SwiftSentry/SentrySDK.swift
@@ -53,6 +53,10 @@ public enum SentrySDK {
             sentry_options_set_debug(o, 1)
         }
 
+        if let handlerPath = options.crashHandlerPath {
+          sentry_options_set_handler_path(o, handlerPath.path.cString(using: .utf8))
+        }
+
         if let release = options.releaseName {
             sentry_options_set_release(o, release.cString(using: .utf8))
         }


### PR DESCRIPTION
Sometimes it's helpful to be able to override where the crash handler
executable actually lives for any number of reasons. We can create a new
value in our options and simply set the SDK value if this is non-nil.