### PR TITLE
Expose function to capture EXCEPTION_POINTERS

### DIFF
--- a/Examples/SentryExampleWinUI/Application.swift
+++ b/Examples/SentryExampleWinUI/Application.swift
@@ -55,6 +55,7 @@ public class SentryApplication: SwiftApplication {
         panel.children.append(makeButton("fatalError()") { fatalError("Boom goes the dynamite!") })
         panel.children.append(makeButton("[0][1]") { _ = [0][1] })
         panel.children.append(makeButton("RaiseFailFastException()") { RaiseFailFastException(nil, nil, 0) })
+        panel.children.append(makeButton("Report empty EXCEPTION_POINTERS", onClick: { SentrySDK.capture(exception: EXCEPTION_POINTERS()) }))
 
         m_window.content = panel
     }

--- a/Sources/SwiftSentry/SentrySDK.swift
+++ b/Sources/SwiftSentry/SentrySDK.swift
@@ -5,6 +5,10 @@ import sentry
 
 import Foundation
 
+#if os(Windows)
+import WinSDK
+#endif
+
 public enum SentrySDK {
     /// Whether or not the application crashed during it's last run.
     /// - note: This value is only accurate after the SDK have been initialized.
@@ -128,4 +132,11 @@ public enum SentrySDK {
 
       return cachePath
     }
+
+    #if os(Windows)
+    public static func capture(exception: EXCEPTION_POINTERS) {
+      var ctx = sentry_ucontext_t(exception_ptrs: exception)
+      sentry_handle_exception(&ctx)
+    }
+    #endif
 }


### PR DESCRIPTION
We need a way to manually report crashes to Sentry or exceptions that
will crash the application. Sentry does this by using a struct which
contains an EXCEPTION_POINTERS to try to send it into the web service.
We can expose this function and add a new button in our test application
which creates an empty EXCEPTION_POINTERS to send into the crash system.