### PR TITLE
Add captureException method to sentrySDK

### DIFF
--- a/Examples/SentryExampleWinUI/Application.swift
+++ b/Examples/SentryExampleWinUI/Application.swift
@@ -5,6 +5,7 @@ import SwiftSentry
 import UWP
 import WinSDK
 import WinUI
+import WindowsFoundation
 
 @main
 public class SentryApplication: SwiftApplication {
@@ -28,6 +29,34 @@ public class SentryApplication: SwiftApplication {
             failWith()
         }
     }
+
+    private func setupUnhandledExceptionReporting() {
+        Application.current.unhandledException.addHandler { (sender, args:UnhandledExceptionEventArgs!) in
+            let message = "Unhandled exception in \(String(describing: sender)): \(args.message)"
+            print("XYZ Unhandled Application exception: \(message)")
+            fflush(stdout)
+
+            _ = SentrySDK.captureException(type: "UnhandledException", description: message)
+
+            if !args.handled {
+                // The app will crash right after, we need to flush the Sentry event queue synchronously.
+                _ = SentrySDK.flush(timeout: 20 * 1000) // wait up for Sentry to flush events before crashing
+            }
+        }
+    }
+
+    class StowedExceptionButton: Button {
+        override func onPointerPressed(_: PointerRoutedEventArgs!) throws {
+            throw Error(hr: HRESULT(E_FAIL))
+        }
+    }
+
+    private lazy var stowedExceptionButton: Button = {
+        let button = StowedExceptionButton()
+        button.horizontalAlignment = .stretch
+        button.content = "Stowed Exception"
+        return button
+    }()
 
     override public func onLaunched(_ args: WinUI.LaunchActivatedEventArgs) {
         m_window.title = "SwiftSentry Example WinUI App"
@@ -55,7 +84,8 @@ public class SentryApplication: SwiftApplication {
         panel.children.append(makeButton("fatalError()") { fatalError("Boom goes the dynamite!") })
         panel.children.append(makeButton("[0][1]") { _ = [0][1] })
         panel.children.append(makeButton("RaiseFailFastException()") { RaiseFailFastException(nil, nil, 0) })
-        panel.children.append(makeButton("Report empty EXCEPTION_POINTERS", onClick: { SentrySDK.capture(exception: EXCEPTION_POINTERS()) }))
+        panel.children.append(stowedExceptionButton)
+        panel.children.append(makeButton("Report custom exception", onClick: { _ = SentrySDK.captureException(type: "CustomException", description: "exception created from an example") }))
 
         m_window.content = panel
     }


### PR DESCRIPTION
Adds a captureException method that creates and captures an exception using a
stacktrace from the current thread and the type and description given as
arguments.

Also add stowedException button to the example

