### PR TITLE
Add an API to set the shutdown timeout value

### DIFF
--- a/Sources/SwiftSentry/Options.swift
+++ b/Sources/SwiftSentry/Options.swift
@@ -13,6 +13,7 @@ public final class Options {
   public var crashHandlerPath: URL?
   public var beforeSend: ((AnyObject) -> AnyObject)?
   public var debug: Bool = false
+  public var shutdownTimeout: Int?
   public var releaseName: String? = {
     guard let info = Bundle.main.infoDictionary else {
       return nil

--- a/Sources/SwiftSentry/Options.swift
+++ b/Sources/SwiftSentry/Options.swift
@@ -13,7 +13,7 @@ public final class Options {
   public var crashHandlerPath: URL?
   public var beforeSend: ((AnyObject) -> AnyObject)?
   public var debug: Bool = false
-  public var shutdownTimeout: Int?
+  public var shutdownTimeout: TimeInterval?
   public var releaseName: String? = {
     guard let info = Bundle.main.infoDictionary else {
       return nil

--- a/Sources/SwiftSentry/SentrySDK.swift
+++ b/Sources/SwiftSentry/SentrySDK.swift
@@ -72,6 +72,10 @@ public enum SentrySDK {
             }, nil)
         }
 
+        if let shutdownTimeout = options.shutdownTimeout {
+            sentry_options_set_shutdown_timeout(o, UInt64(shutdownTimeout))
+        }
+
         sentry_init(o)
     }
 


### PR DESCRIPTION
The default shutdown timeout is set to 2s in Sentry but it looks like we might sometime need more time on Windows (the current value is set to 20s), exposing this API will let us change this value from the Arc repo.