### PR TITLE
Make captureExceptionRecord use the crashpad SEH

### DIFF
--- a/Sources/SwiftSentry/SentrySDK.swift
+++ b/Sources/SwiftSentry/SentrySDK.swift
@@ -125,34 +125,16 @@ public enum SentrySDK {
     //
     // It differs from captureException by the fact that it captures the stacktrace of the
     // exception instead of the current stacktrace.
-    public static func captureExceptionRecord(type: String, description: String, exceptionRecord: UnsafeMutablePointer<EXCEPTION_POINTERS>) -> SentryId {
-        let event = Event(level: SentryLevel.fatal)
-        event.message = description
-
-        let eventSerialized = event.serialized()
-        let exception = sentry_value_new_exception(type, description)
-        sentry_event_add_exception(eventSerialized, exception)
-        let thread = sentry_value_new_thread(UInt64(GetCurrentThreadId()), Thread.current.name)
-
-        let maxStackDepth : Int = 128
-
-        // Extract the stacktrace from the exception record and add it to the event.
-        var backtrace = Array<UnsafeMutableRawPointer?>(repeating: nil, count: maxStackDepth)
-        var frameCount: size_t = 0
+    //
+    // From the sentry documentation:
+    // This is safe to be called from a crashing thread and may not return.
+    public static func captureExceptionRecord(exceptionRecord: UnsafeMutablePointer<EXCEPTION_POINTERS>) {
         var exceptionContext = sentry_ucontext_s()
 
         exceptionContext.exception_ptrs = exceptionRecord.pointee
-        backtrace.withUnsafeMutableBufferPointer { backtraceBuffer in
-            withUnsafePointer(to: &exceptionContext) { exceptionContextPtr in
-                frameCount = sentry_unwind_stack_from_ucontext(exceptionContextPtr, backtraceBuffer.baseAddress!, maxStackDepth)
-                sentry_value_set_stacktrace(thread, backtraceBuffer.baseAddress, frameCount)
-                sentry_event_add_thread(eventSerialized, thread)
-            }
+        withUnsafePointer(to: &exceptionContext) { exceptionContextPtr in
+            sentry_handle_exception(exceptionContextPtr)
         }
-
-        let id = sentry_capture_event(eventSerialized)
-
-        return SentryId(value: id)
     }
 #endif
 


### PR DESCRIPTION
The reason why we need to setup a VEH in Arc and call this `captureExceptionRecord` is that Arc's SEH handler doesn't always gets called on failure, leading to some missing crash reports. 

We used to manually rebuild a Sentry report and emit it manually from `captureExceptionRecord` but it's actually much better to simply call the `sentry_handle_exception` as it'll result in calling the crashpad SEH function that should have been called in the first place! This lead to a more complete crash report, see this comparison :
![image](https://github.com/thebrowsercompany/swift-sentry/assets/245780/d935914c-0299-4d70-ac4f-37fb78218e82)

(the actual crashes are different, that's not relevant here) The main differences are that the report on the left contains way more information than the one on the right:
- The event name is less generic, it's the name of the function that caused the crash
- The stack traces of all the threads is present
- There is some tags about the crash
- The register values are present
