### PR TITLE
Retrieve the crashpad_handler IPC endpoint from sentry-native

### DIFF
--- a/Sources/SwiftSentry/SentrySDK.swift
+++ b/Sources/SwiftSentry/SentrySDK.swift
@@ -94,7 +94,7 @@ public enum SentrySDK {
         sentry_init(o)
 
         #if os(Windows)
-            let path = sentry_options_get_handler_ipc_pathw(o)
+            let path = sentry_options_get_handler_ipc_pipew(o)
 
             // It has to be this name rather than "SENTRY..." or "ARC..."
             // because the Chromium sandbox is specially set up to allow this

--- a/Sources/SwiftSentry/SentrySDK.swift
+++ b/Sources/SwiftSentry/SentrySDK.swift
@@ -92,6 +92,17 @@ public enum SentrySDK {
         }
 
         sentry_init(o)
+
+        #if os(Windows)
+            let path = sentry_options_get_handler_ipc_pathw(o)
+
+            // It has to be this name rather than "SENTRY..." or "ARC..."
+            // because the Chromium sandbox is specially set up to allow this
+            // environment variable through to child processes.
+            "CHROME_CRASHPAD_PIPE_NAME".withCString(encodedAs: UTF16.self) {
+                SetEnvironmentVariableW($0, path)
+            }
+        #endif
     }
 
     public static func setUser(_ user: User?) {


### PR DESCRIPTION
After crashpad_handler has started, grab the endpoint of the pipe server that crashpad_handler is running, and stash it in an environment variable.

This method, and the name of envvar matches Chromium https://source.chromium.org/search?q=CHROME_CRASHPAD%20case:yes&sq=&ss=chromium which will allow the child process registration to work in the same way, and let the environment variable through the sandbox to child processes which otherwise have no environment.

Added to sentry-native here: https://github.com/thebrowsercompany/sentry-native/pull/10.

Testing: manual via System Informer 
<img width="466" alt="image" src="https://github.com/thebrowsercompany/swift-sentry/assets/1822/898c20cf-16ba-4856-9d1b-849d2cd07463">
