### PR TITLE
captureExceptionRecord: Create the exception context record if it's missing

### DIFF
--- a/Sources/SwiftSentry/SentrySDK.swift
+++ b/Sources/SwiftSentry/SentrySDK.swift
@@ -169,21 +169,20 @@ public enum SentrySDK {
         }
 
         let stowedExceptionCode = 0xC000027B
-        var context = CONTEXT()
-        // Crashpad will not be able to report the exception if the context record is nil, this can happen if the exception
-        // is coming from RaiseFailFastException as the "contextRecord" argument of this function is optional. In this case,
-        // it's necessary to capture the context manually here.
-        if exceptionRecord.pointee.ContextRecord == nil {
-            let currentThread : HANDLE = GetCurrentThread();
-            RtlCaptureContext(&context);
-            exceptionRecord.pointee.ContextRecord = withUnsafePointer(to: &context) { ptr -> PCONTEXT? in
-                return UnsafeMutablePointer(mutating: ptr)
-            }
-        }
-
         if record.pointee.ExceptionCode == stowedExceptionCode {
             captureStowedExceptions(exceptionRecord: record.pointee)
         } else {
+            // Crashpad will not be able to report the exception if the context record is nil, this can happen if the exception
+            // is coming from RaiseFailFastException as the "contextRecord" argument of this function is optional. In this case,
+            // it's necessary to capture the context manually here.
+            var context = CONTEXT()
+            if exceptionRecord.pointee.ContextRecord == nil {
+                RtlCaptureContext(&context);
+                exceptionRecord.pointee.ContextRecord = withUnsafePointer(to: &context) { ptr -> PCONTEXT? in
+                    return UnsafeMutablePointer(mutating: ptr)
+                }
+            }
+
             exceptionContext.exception_ptrs = exceptionRecord.pointee
             withUnsafePointer(to: &exceptionContext) { exceptionContextPtr in
                 sentry_handle_exception(exceptionContextPtr)


### PR DESCRIPTION
Exceptions raised by `RaiseFailFastException` don't always have a ContextRecord, which will cause crashpad to fail to report them. In this case we need to manually create this context record.

This can happen when detouring RaiseFailFastException, as the pContextRecord argument of this function is optional. The documentation about this argument says: `A pointer to a [CONTEXT](https://learn.microsoft.com/en-us/windows/desktop/api/winnt/ns-winnt-arm64_nt_context) structure that contains the context information. If NULL, this function generates the context (however, the context will not exactly match the context of the caller).` , doing something similar in `captureExceptionRecord` help ensure that we don't drop any exceptions.