### PR TITLE
add restricted error information to sentry events

### DIFF
--- a/Sources/SwiftSentry/Exception.swift
+++ b/Sources/SwiftSentry/Exception.swift
@@ -3,7 +3,7 @@ import sentry
 
 struct Exception {
     let type: String
-    let description: string
+    let description: String
     let value: sentry_value_t
 
     init(type: String, description: String) {

--- a/Sources/SwiftSentry/Exception.swift
+++ b/Sources/SwiftSentry/Exception.swift
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: BSD-3-Clause
+import sentry
+
+struct Exception {
+    let type: String
+    let description: string
+    let value: sentry_value_t
+
+    init(type: String, description: String) {
+        self.type = type
+        self.description = description
+        self.value = sentry_value_new_exception(type, description)
+    }
+
+
+    func setMechanism(_ mechanism: Mechanism) {
+        sentry_value_set_by_key(value, "mechanism", mechanism.value)
+    }
+}

--- a/Sources/SwiftSentry/Headers/RestrictedErrorInformation.h
+++ b/Sources/SwiftSentry/Headers/RestrictedErrorInformation.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <windows.h>
+#include <minwindef.h>
+#include <combaseapi.h>
+
+// Since C++ interop doesn't support virtual methods, we define the C interface
+// ourselves to ensure consistency
+typedef interface IRestrictedErrorInfo IRestrictedErrorInfo;
+EXTERN_C const IID IID_IRestrictedErrorInfo;
+typedef struct IRestrictedErrorInfoVtbl
+{
+    BEGIN_INTERFACE
+
+    DECLSPEC_XFGVIRT(IUnknown, QueryInterface)
+    HRESULT ( STDMETHODCALLTYPE *QueryInterface )(
+        __RPC__in IRestrictedErrorInfo * This,
+        /* [in] */ __RPC__in REFIID riid,
+        /* [annotation][iid_is][out] */
+        _COM_Outptr_  void **ppvObject);
+
+    DECLSPEC_XFGVIRT(IUnknown, AddRef)
+    ULONG ( STDMETHODCALLTYPE *AddRef )(
+        __RPC__in IRestrictedErrorInfo * This);
+
+    DECLSPEC_XFGVIRT(IUnknown, Release)
+    ULONG ( STDMETHODCALLTYPE *Release )(
+        __RPC__in IRestrictedErrorInfo * This);
+
+    DECLSPEC_XFGVIRT(IRestrictedErrorInfo, GetErrorDetails)
+    HRESULT ( STDMETHODCALLTYPE *GetErrorDetails )(
+        __RPC__in IRestrictedErrorInfo * This,
+        /* [out] */ __RPC__deref_out_opt BSTR *description,
+        /* [out] */ __RPC__out HRESULT *error,
+        /* [out] */ __RPC__deref_out_opt BSTR *restrictedDescription,
+        /* [out] */ __RPC__deref_out_opt BSTR *capabilitySid);
+
+    DECLSPEC_XFGVIRT(IRestrictedErrorInfo, GetReference)
+    HRESULT ( STDMETHODCALLTYPE *GetReference )(
+        __RPC__in IRestrictedErrorInfo * This,
+        /* [out] */ __RPC__deref_out_opt BSTR *reference);
+
+    END_INTERFACE
+} IRestrictedErrorInfoVtbl;
+
+interface IRestrictedErrorInfo
+{
+    CONST_VTBL struct IRestrictedErrorInfoVtbl *lpVtbl;
+};
+
+STDAPI GetRestrictedErrorInfo(_Nullable IRestrictedErrorInfo **);

--- a/Sources/SwiftSentry/Headers/module.modulemap
+++ b/Sources/SwiftSentry/Headers/module.modulemap
@@ -4,3 +4,9 @@ module stowedExceptions [system] {
   header "StowedExceptionInformation.h"
   export *
 }
+
+module RoErrorAPI [system] {
+  header "RestrictedErrorInformation.h"
+  export *
+  link "combase"
+}

--- a/Sources/SwiftSentry/Headers/module.modulemap
+++ b/Sources/SwiftSentry/Headers/module.modulemap
@@ -8,5 +8,4 @@ module stowedExceptions [system] {
 module RoErrorAPI [system] {
   header "RestrictedErrorInformation.h"
   export *
-  link "combase"
 }

--- a/Sources/SwiftSentry/Mechanism.swift
+++ b/Sources/SwiftSentry/Mechanism.swift
@@ -11,6 +11,6 @@ internal struct Mechanism {
         self.type = type
         self.handled = handled
         sentry_value_set_by_key(value, "type", sentry_value_new_string(type))
-        sentry_value_set_by_key(value, "handled", sentry_value_new_boolean(handled))
+        sentry_value_set_by_key(value, "handled", sentry_value_new_bool(Int32(handled ? 1 : 0)))
     }
 }

--- a/Sources/SwiftSentry/Mechanism.swift
+++ b/Sources/SwiftSentry/Mechanism.swift
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+import sentry
+
+internal struct Mechanism {
+    let value: sentry_value_t
+    let type: String
+    let handled: Bool
+    init(type: String, handled: Bool) {
+        self.value = sentry_value_new_object()
+        self.type = type
+        self.handled = handled
+        sentry_value_set_by_key(value, "type", sentry_value_new_string(type))
+        sentry_value_set_by_key(value, "handled", sentry_value_new_boolean(handled))
+    }
+}

--- a/Sources/SwiftSentry/SentrySDK.swift
+++ b/Sources/SwiftSentry/SentrySDK.swift
@@ -299,7 +299,7 @@ public enum SentrySDK {
               let mechanism = Mechanism(type: "generic", handled: false)
               exception.setMechanism(mechanism)
             }
-            sentry_value_append(exceptions, exception)
+            sentry_value_append(exceptions, exception.value)
             ips.deallocate()
             return true
         }

--- a/Sources/SwiftSentry/Utilities/ErrorHelpers.swift
+++ b/Sources/SwiftSentry/Utilities/ErrorHelpers.swift
@@ -1,5 +1,72 @@
 #if os(Windows)
+import RoErrorAPI
 import WinSDK
+
+struct RestrictedErrorInfo {
+  let hr: HRESULT
+  let description: String
+}
+
+func getRestrictedErrorInfo() -> RestrictedErrorInfo? {
+  var errorInfo: UnsafeMutablePointer<IRestrictedErrorInfo>?
+  guard GetRestrictedErrorInfo(&errorInfo) == S_OK, let errorInfo else { return nil }
+  defer {
+    _ = errorInfo.pointee.lpVtbl.pointee.Release(errorInfo)
+  }
+
+  var errorDescription: BSTR?
+  var restrictedDescription: BSTR?
+  var capabilitySid: BSTR?
+  defer {
+    SysFreeString(errorDescription)
+    SysFreeString(restrictedDescription)
+    SysFreeString(capabilitySid)
+  }
+  var resultLocal: HRESULT = S_OK
+  _ = errorInfo.pointee.lpVtbl.pointee.GetErrorDetails(
+    errorInfo,
+    &errorDescription,
+    &resultLocal,
+    &restrictedDescription,
+    &capabilitySid)
+
+  // Favor restrictedDescription as this is a more user friendly message, which
+  // is intended to be displayed to the caller to help them understand why the
+  // api call failed. If it's not set, then fallback to the generic error message
+  // for the result
+  if SysStringLen(restrictedDescription) > 0 {
+    return .init(hr: resultLocal, description: String(decodingCString: restrictedDescription!, as: UTF16.self))
+  } else if SysStringLen(errorDescription) > 0 {
+    return .init(hr: resultLocal, description: String(decodingCString: errorDescription!, as: UTF16.self))
+  } else {
+    return .init(hr: resultLocal, description: hrToString(resultLocal))
+  }
+}
+
+@_transparent
+private func MAKELANGID(_ p: WORD, _ s: WORD) -> DWORD {
+  return DWORD((s << 10) | p)
+}
+
+private func hrToString(_ hr: HRESULT) -> String {
+  let dwFlags: DWORD = DWORD(FORMAT_MESSAGE_ALLOCATE_BUFFER)
+                       | DWORD(FORMAT_MESSAGE_FROM_SYSTEM)
+                       | DWORD(FORMAT_MESSAGE_IGNORE_INSERTS)
+
+    var buffer: UnsafeMutablePointer<WCHAR>? = nil
+    let dwResult: DWORD = withUnsafeMutablePointer(to: &buffer) {
+      $0.withMemoryRebound(to: WCHAR.self, capacity: 2) {
+        FormatMessageW(dwFlags, nil, DWORD(bitPattern: hr),
+                       MAKELANGID(WORD(LANG_NEUTRAL), WORD(SUBLANG_DEFAULT)),
+                       $0, 0, nil)
+      }
+    }
+    guard dwResult > 0, let message = buffer else {
+      return "HRESULT(\(hr.stringRepresentation))"
+    }
+    defer { LocalFree(buffer) }
+    return "\(hr.stringRepresentation)) - \(String(decodingCString: message, as: UTF16.self))"
+}
 
 extension HRESULT {
   var stringRepresentation: String {

--- a/Sources/SwiftSentry/Utilities/ErrorHelpers.swift
+++ b/Sources/SwiftSentry/Utilities/ErrorHelpers.swift
@@ -12,7 +12,6 @@ struct RestrictedErrorInfo {
 //   - https://github.com/thebrowsercompany/swift-winrt/blob/a73deec57624d04776f0d2b97882bd330749ac39/swiftwinrt/Resources/Support/Error.swift#L104
 func getRestrictedErrorInfo() -> RestrictedErrorInfo? {
 
-- method hrToString is a copy of hrToString (link) using HRESULT.stringRepresentation
   var errorInfo: UnsafeMutablePointer<IRestrictedErrorInfo>?
   guard GetRestrictedErrorInfo(&errorInfo) == S_OK, let errorInfo else { return nil }
   defer {

--- a/Sources/SwiftSentry/Utilities/ErrorHelpers.swift
+++ b/Sources/SwiftSentry/Utilities/ErrorHelpers.swift
@@ -7,7 +7,12 @@ struct RestrictedErrorInfo {
   let description: String
 }
 
+// Method getRestrictedErrorInfo is a modified version of getErrorDescription from swift-winrt. It's been modified to just grab
+// the error info and doesn't have to match based off HRESULT.
+//   - https://github.com/thebrowsercompany/swift-winrt/blob/a73deec57624d04776f0d2b97882bd330749ac39/swiftwinrt/Resources/Support/Error.swift#L104
 func getRestrictedErrorInfo() -> RestrictedErrorInfo? {
+
+- method hrToString is a copy of hrToString (link) using HRESULT.stringRepresentation
   var errorInfo: UnsafeMutablePointer<IRestrictedErrorInfo>?
   guard GetRestrictedErrorInfo(&errorInfo) == S_OK, let errorInfo else { return nil }
   defer {
@@ -48,6 +53,7 @@ private func MAKELANGID(_ p: WORD, _ s: WORD) -> DWORD {
   return DWORD((s << 10) | p)
 }
 
+// hrToString is a copy of hrToString from swift-winrt, with changes to use HRESULT.stringRepresentation
 private func hrToString(_ hr: HRESULT) -> String {
   let dwFlags: DWORD = DWORD(FORMAT_MESSAGE_ALLOCATE_BUFFER)
                        | DWORD(FORMAT_MESSAGE_FROM_SYSTEM)


### PR DESCRIPTION
This change adds the last error reported via `GetRestrictedErrorInfo`. This error context is captured by WinUI when they call `RoFailFastWithErrorContext`.

If there is error information, a few things are done:
1. the message is updated to point the user to this as being the culprit of what caused the app to crash. 
2. a new exception with this is added to the front of the list
3. fingerprinting favors the description of the error instead of number of stowed exceptions


Here is an example event: https://thebrowsercompany.sentry.io/issues/5741140584/events/cffb904a4fe94256a8f9ad24cb10a97f/?project=4505954005876736