### PR TITLE
Add `customReleaseName` to Options

### DIFF
--- a/Sources/SwiftSentry/Options.swift
+++ b/Sources/SwiftSentry/Options.swift
@@ -14,7 +14,20 @@ public final class Options {
   public var beforeSend: ((AnyObject) -> AnyObject)?
   public var debug: Bool = false
   public var shutdownTimeout: TimeInterval?
+
+  /// Overrides `releaseName`. Useful if your executable doesn't 
+  /// have an associated Info.plist or you just want to hardcode a value.
+  public var customReleaseName: String? = nil
+
+  /// Returns a string computed by the main bundle's info dictionary if present.
+  /// "`CFBundleIdentifier`@`CFBundleShortVersionString`+`CFBundleVersion`"
+  ///
+  /// If `customReleaseName` is set, that value will always be used instead.
   public var releaseName: String? = {
+    if let customReleaseName {
+      return customReleaseName
+    }
+
     guard let info = Bundle.main.infoDictionary else {
       return nil
     }


### PR DESCRIPTION
I needed a way to provide a custom `releaseName`, so here it is! This is super useful for folks who don't want to ship a Info.plist file with their app for a multitude of reasons.