### PR TITLE
Add removeTag to SentrySDK

### DIFF
--- a/Sources/SwiftSentry/SentrySDK.swift
+++ b/Sources/SwiftSentry/SentrySDK.swift
@@ -125,6 +125,10 @@ public enum SentrySDK {
         sentry_set_tag(key, value)
     }
 
+    public static func removeTag(key: String) {
+        sentry_remove_tag(key)
+    }
+
     public static func capture(event: Event) -> SentryId {
         let eventSerialized = event.serialized()
         let id = sentry_capture_event(eventSerialized)


### PR DESCRIPTION
This adds a removeTag function to SentrySDK, matching the behavor already available in the macOS version of Sentry.