### PR TITLE
Revert "add `customReleaseName` to Options"

### DIFF
--- a/Sources/SwiftSentry/Options.swift
+++ b/Sources/SwiftSentry/Options.swift
@@ -14,20 +14,7 @@ public final class Options {
   public var beforeSend: ((AnyObject) -> AnyObject)?
   public var debug: Bool = false
   public var shutdownTimeout: TimeInterval?
-
-  /// Overrides `releaseName`. Useful if your executable doesn't 
-  /// have an associated Info.plist or you just want to hardcode a value.
-  public var customReleaseName: String? = nil
-
-  /// Returns a string computed by the main bundle's info dictionary if present.
-  /// "`CFBundleIdentifier`@`CFBundleShortVersionString`+`CFBundleVersion`"
-  ///
-  /// If `customReleaseName` is set, that value will always be used instead.
   public var releaseName: String? = {
-    if let customReleaseName {
-      return customReleaseName
-    }
-
     guard let info = Bundle.main.infoDictionary else {
       return nil
     }


### PR DESCRIPTION
Reverts dea47bde3d53f0eb45e02f2f32821cffe8e81bd8 aka https://github.com/thebrowsercompany/swift-sentry/pull/52 because [it did not build](https://github.com/thebrowsercompany/swift-sentry/pull/52#issuecomment-3050238238)