### PR TITLE
Fix `customReleaseName` usage in `releaseName`

### DIFF
--- a/Sources/SwiftSentry/Options.swift
+++ b/Sources/SwiftSentry/Options.swift
@@ -23,7 +23,7 @@ public final class Options {
   /// "`CFBundleIdentifier`@`CFBundleShortVersionString`+`CFBundleVersion`"
   ///
   /// If `customReleaseName` is set, that value will always be used instead.
-  public var releaseName: String? = {
+  public var releaseName: String? {
     if let customReleaseName {
       return customReleaseName
     }
@@ -39,7 +39,7 @@ public final class Options {
     }
 
     return "\(bundle)@\(version)+\(build)"
-  }()
+  }
 
   public init() {}
 }


### PR DESCRIPTION
fixed issue where customReleaseName is referenced before initialization