### PR TITLE
Expose SentryId.empty

### DIFF
--- a/Sources/SwiftSentry/SentryId.swift
+++ b/Sources/SwiftSentry/SentryId.swift
@@ -64,3 +64,7 @@ internal extension SentryId {
     self.uuid = UUID(uuidString: String(cString: cString)) ?? .empty
   }
 }
+
+public extension SentryId {
+  static var empty = SentryId(UUID: .empty)
+}


### PR DESCRIPTION
Expose SentryId.empty as the macOS Sentry does.